### PR TITLE
Fixed getting the constructor for pure sodium

### DIFF
--- a/src/main/java/com/limeshulkerbox/bsvsb/mixin/MixinVideoOptionsScreen.java
+++ b/src/main/java/com/limeshulkerbox/bsvsb/mixin/MixinVideoOptionsScreen.java
@@ -81,10 +81,16 @@ public abstract class MixinVideoOptionsScreen extends GameOptionsScreen {
         if (SodiumOptionsGUIClass == null) {
             try {
                 SodiumOptionsGUIClass = Class.forName("me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI");
-                SodiumOptionsGUIClassCtor = SodiumOptionsGUIClass.getConstructor(Screen.class);
+                //Use declaredConstructors to get the correct constructor, will break when adding more constructors
+                //Also consider using the public static method (public static Screen createScreen(Screen currentScreen)) (https://github.com/CaffeineMC/sodium-fabric/blob/db7c77a0960c166e4177acbbabd892167fcd0271/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptionsGUI.java#L124C5-L124C62)
+                //This will most likely also need a rework in the future, because the sodium gui is getting reworked (https://github.com/CaffeineMC/sodium-fabric/issues/2562#issuecomment-2180808114)
+                SodiumOptionsGUIClassCtor = SodiumOptionsGUIClass.getDeclaredConstructors()[0];
+                //New constructor is private, so make it accessible
+                SodiumOptionsGUIClassCtor.setAccessible(true);
                 SodiumOptionsGUIClassPagesField = SodiumOptionsGUIClass.getDeclaredField("pages");
                 SodiumOptionsGUIClassPagesField.setAccessible(true);
             } catch (Exception e) {
+                System.out.println("crash ensure");
                 e.printStackTrace();
             }
         }
@@ -97,6 +103,7 @@ public abstract class MixinVideoOptionsScreen extends GameOptionsScreen {
             assert this.client != null;
             this.client.setScreen((Screen) SodiumOptionsGUIClassCtor.newInstance(this));
         } catch (Exception e) {
+            System.out.println("crash on sodiumVideoOptions");
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
This should be a fix for pure sodium, because right now in the current version of Sodium in 1.20.1 it crashes, because the current way of getting the correct constructor isn't working for me.

I used a slightly different approach, which at least for me, works now.

I wrote some comments in the code to explain what i am doing differently now.

Tested only in 1.20.1, without sodium extra or reese.

EDIT: You can remove my debug comments on the two e.printStacktrace(), I forgot to remove them c: